### PR TITLE
Fix missing 'require fileutils' + README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,30 @@
 # xcode-build-times-rendering
+
 Xcode build times visualization per target
 ![image](https://user-images.githubusercontent.com/119268/45782819-abd2aa00-bc6c-11e8-9ee0-114c020f238a.png)
 
-# Installation
-```
+## Installation
+
+```sh
 [sudo] gem install xcode-build-times
 ```
-# Injection
-In order to gather target build times, we're about to add build phases "START" and "END" for **EACH** target in **EACH** project at specified path.
-```
+
+## Injection in your project
+
+In order to gather target build times, run the following command. This will add script build phases named "Timing START" and "Timing END" for **EACH** target in **EACH** project at specified path.
+
+```sh
 xcode-build-times install ~/Projects/<My_slowly_building_project>/
 ```
+
 ![image](https://user-images.githubusercontent.com/119268/45782420-898c5c80-bc6b-11e8-9200-d54dbc5ea56f.png)
 
-# Events
-After installation, all build events will be saved to `~/.timings.xcode` file  
+## Events file
+
+Once you've run the `install` command above, all build events will be saved to `~/.timings.xcode` file every time you build your project.  
 **NOTE**: You can override this default setting by passing `--events-file` parameter on installation script
-```
+
+```json
 ...
 {"date":"2018-09-19T22:52:04.1537386724", "taskName":"A", "event":"start"},
 {"date":"2018-09-19T22:53:01.1537386781", "taskName":"A", "event":"end"},
@@ -25,21 +33,39 @@ After installation, all build events will be saved to `~/.timings.xcode` file
 ...
 ```
 
-# Generating Visualization Events
+## Generating Visualization Events
+
 Once desired build is done, it's time to dump raw events in place we need in order to render them.
-This can be done by running  
-**NOTE**: You can use differnt timings files by passing `--events-file` parameter
-```
+This can be done by running:
+
+```sh
 xcode-build-times generate [--events-file <path>]
 ```
 
-# Open gantt.html
+**NOTE**: You can use a different timings file by passing `--events-file` parameter
+
+## Open gantt.html
+
 It's time to see results. Just open **xcode-build-times-chart/gantt.html**.
 
-## Libraries and Kudos
+## Uninstallation
+
+Once you are done benchmarking your project and want to remove the "Timing START' / "Timing END" build phases from your projects, just run:
+
+```sh
+xcode-build-times uninstall ~/Projects/<My_slowly_building_project>/
+```
+
+(You can also delete your events file and the `xcode-build-times-chart/` containing your reports)
+
+---
+
+# Libraries and Kudos
+
 [d3js](https://d3js.org/) - JavaScript library for manipulating documents based on data  
 [xcodeproj](https://github.com/CocoaPods/Xcodeproj) - Create and modify Xcode projects from Ruby.  
 [d3js-gantt](https://github.com/dk8996/Gantt-Chart) - Gantt chart for d3js by [@dk8996](https://github.com/dk8996)
 
-## P.S.
+# P.S.
+
 If something doesn't work - please [fix it](https://github.com/PaulTaykalo/xcode-build-times-rendering/pulls)

--- a/lib/xcode-build-times.rb
+++ b/lib/xcode-build-times.rb
@@ -2,6 +2,7 @@
 #encoding: utf-8
 require 'xcodeproj'
 require_relative 'stringcolors'
+require 'fileutils'
 
 class XcodeBuildTimer
 


### PR DESCRIPTION
Hello!

Thanks for the awesome project!
Here's a quick PR to fix both a crash and some typos

# Fix crash with `FileUtils`

First time I installed the gem (version `0.1.1`) and ran the `generate` command I got this ruby error:

```sh
$ xcode-build-times generate --events-file ./timings-xcode.json
[CHART] Will copy chart to /Users/me/Documents/Dev/my-ios-project
/Users/me/.gem/gems/xcode-build-times-0.1.1/lib/xcode-build-times.rb:107:in `generate_events_js': uninitialized constant XcodeBuildTimer::FileUtils (NameError)
Did you mean?  FileTest
	from /Users/me/.gem/gems/xcode-build-times-0.1.1/bin/xcode-build-times:33:in `<top (required)>'
	from /Users/me/.gem/bin/xcode-build-times:22:in `load'
	from /Users/me/.gem/bin/xcode-build-times:22:in `<main>'
```

I fixed it by simply adding a `require 'fileutils'` in the code 🎉 

# README

I took the occasion of that PR to fix some small typos in the README, add some more instructions to it (like uninstall) and reword it a little.