### PR TITLE
Use working directory for install, uninstall

### DIFF
--- a/bin/xcode-build-times
+++ b/bin/xcode-build-times
@@ -11,17 +11,19 @@ options = {
 arguments = ARGV.clone
 until arguments.empty?
   item = arguments.shift
+  argumentProjectPath = arguments.shift
+  projectPath = argumentProjectPath.nil? ? Dir.pwd : argumentProjectPath
   case item
   when 'install'
     options[:command] = item
-    options[:inject_path] = File.expand_path(arguments.shift)
+    options[:inject_path] = projectPath
   when 'uninstall'
     options[:command] = item
-    options[:inject_path] = File.expand_path(arguments.shift)
+    options[:inject_path] = projectPath
   when 'generate'
     options[:command] = item
   when '--events-file'
-    options[:events_file_path] = File.expand_path(arguments.shift)
+    options[:events_file_path] = argumentProjectPath
   else
     puts '[?PARAMETER?] '.yellow + "Unknown parameter #{item}"
   end


### PR DESCRIPTION
Hi!
It's nice to have default parameters for `install`, `uninstall` when you run directly from the project directory
If you're good with the PR, I will update README.md