### PR TITLE
Fix `events_file_path` not working correctly

### DIFF
--- a/bin/xcode-build-times
+++ b/bin/xcode-build-times
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 
-require 'xcode-build-times'
+require_relative '../lib/xcode-build-times.rb'
 
 options = {
-  :events_file_path => '~/.timings.xcode',
+  :events_file_path => '${HOME}/.timings.xcode',
   :command => 'unknown'
 }
 


### PR DESCRIPTION
This is a fix needed when setting custom `events_file_path` (`--events-file` option) with calling from `./bin/xcode-build-times` rather than from gem.